### PR TITLE
Add future/past queryset options

### DIFF
--- a/events/models.py
+++ b/events/models.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 
 from cms.models import PlaceholderField
 from filer.fields.image import FilerImageField
+from django.db.models.functions import Now
 
 from mixins.models import (
     PublishingMixin,
@@ -58,7 +59,23 @@ class EventQuerySet(PublishingQuerySetMixin):
     Custom QuerySet model to override the base one
     """
 
-    pass
+    def future(self, user=None):
+        """
+        Return the published queryset for future events, or all if user is admin
+        """
+        if user and user.is_staff:
+            return self.all()
+
+        return self.filter(is_published=True, start_at__gte=Now())
+
+    def past(self, user=None):
+        """
+        Return the published queryset for past events, or all if user is admin
+        """
+        if user and user.is_staff:
+            return self.all()
+
+        return self.filter(is_published=True, start_at__lt=Now())
 
 
 class Event(TimestampMixin, PublishingMixin, URLMixin):

--- a/events/tests/conftest.py
+++ b/events/tests/conftest.py
@@ -1,0 +1,27 @@
+from django.utils import timezone
+
+import pytest
+
+from events.models import Event
+
+
+@pytest.fixture
+def unpublished_event():
+    return Event.objects.create(
+        title="Event One",
+        slug="event-one",
+        start_at=timezone.now() - timezone.timedelta(days=1),
+        is_published=False,
+        publish_at=timezone.now() + timezone.timedelta(hours=1),
+    )
+
+
+@pytest.fixture
+def published_event():
+    return Event.objects.create(
+        title="Event Two",
+        slug="event-two",
+        start_at=timezone.now() + timezone.timedelta(days=1),
+        is_published=True,
+        publish_at=timezone.now() - timezone.timedelta(hours=1),
+    )

--- a/events/tests/test_views.py
+++ b/events/tests/test_views.py
@@ -5,6 +5,8 @@ from django.utils import timezone
 import pytest
 from events import models
 
+from .conftest import *
+
 
 @pytest.mark.django_db
 class TestEventView:
@@ -40,19 +42,14 @@ class TestEventView:
         response = client.get(reverse("events:index"))
         assert response.status_code == 200
 
-    def test_unpublished_returns_404(self, event_instance):
+    def test_unpublished_returns_404(self, unpublished_event):
         """
         Test to check that an unpublished event returns a 404
         """
         client = Client()
-        event = models.Event.objects.create(
-            title="Event Two",
-            slug="event-two",
-            start_at=timezone.now(),
-            is_published=False,
-            publish_at=timezone.now() - timezone.timedelta(hours=1),
+        response = client.get(
+            reverse("events:detail", kwargs={"slug": unpublished_event.slug})
         )
-        response = client.get(reverse("events:detail", kwargs={"slug": event.slug}))
 
         assert response.status_code == 404
 

--- a/events/views.py
+++ b/events/views.py
@@ -19,6 +19,14 @@ class EventIndex(ListView):
         """
         return Event.objects.published(user=self.request.user).order_by("-publish_at")
 
+    def get_context_data(self, **kwargs):
+        """
+        Update the context with extra args
+        """
+        context = super().get_context_data(**kwargs)
+        context["future_events"] = Event.objects.future(user=self.request.user).order_by("-start_at")
+        context["past_events"] = Event.objects.past(user=self.request.user).order_by("-start_at")
+        return context
 
 class EventDetail(DetailView):
     """

--- a/events/views.py
+++ b/events/views.py
@@ -24,9 +24,14 @@ class EventIndex(ListView):
         Update the context with extra args
         """
         context = super().get_context_data(**kwargs)
-        context["future_events"] = Event.objects.future(user=self.request.user).order_by("-start_at")
-        context["past_events"] = Event.objects.past(user=self.request.user).order_by("-start_at")
+        context["future_events"] = Event.objects.future(
+            user=self.request.user
+        ).order_by("-start_at")
+        context["past_events"] = Event.objects.past(user=self.request.user).order_by(
+            "-start_at"
+        )
         return context
+
 
 class EventDetail(DetailView):
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "giant-events"
-version = "0.2.2"
+version = "0.2.3"
 description = "A small reusable package that adds an Events app to a project"
 authors = ["Will-Hoey <will.hoey@giantmade.com>"]
 license = "MIT"


### PR DESCRIPTION
Adds 2 new queryset filters to return previous published events and future published events. Based on the design for the Climatecare events page 