### PR TITLE
fix: Update Event model manager. Update past/future conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.5
+- Use `timezone.now()` instead of `Now()` when evaluating past/future querysets
+- Update the past/future filtering conditions so events are moved prematurely.
+
 ## 0.1.2
 - Combine author name fields into one
 - Add Category model

--- a/events/tests/conftest.py
+++ b/events/tests/conftest.py
@@ -7,10 +7,12 @@ from events.models import Event
 
 @pytest.fixture
 def unpublished_event():
+    _date = timezone.now() - timezone.timedelta(days=1)
     return Event.objects.create(
         title="Event One",
         slug="event-one",
-        start_at=timezone.now() - timezone.timedelta(days=1),
+        start_at=_date,
+        end_at=_date,
         is_published=False,
         publish_at=timezone.now() + timezone.timedelta(hours=1),
     )

--- a/events/tests/test_models.py
+++ b/events/tests/test_models.py
@@ -75,7 +75,7 @@ class TestEventQuerySet:
 
     def test_past_queryset(self, published_event, unpublished_event):
         """
-        Test that the past method returns only items with a future date
+        Test that the past method returns only items with a date in the past
         """
 
         future_event = published_event

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "giant-events"
-version = "0.2.4"
+version = "0.2.5"
 description = "A small reusable package that adds an Events app to a project"
 authors = ["Will-Hoey <will.hoey@giantmade.com>"]
 license = "MIT"


### PR DESCRIPTION
Using the Now() function won't account for timezones. Using timezone.now() when rendering the view should fix the lack of awareness.

The initial reason for using `Now` was that we could simply use `queryset = object.filter(time=Now())` and it would be evaluated correctly. However, this isn't really used and we are almost certainly using the methods in a `get_queryset` or equivalent which means the queryset is evaluated on render